### PR TITLE
Encoder drift fix

### DIFF
--- a/Transmitter/src/flashthissecond.c
+++ b/Transmitter/src/flashthissecond.c
@@ -105,7 +105,7 @@ int main(void)
 		actualDegrees = (val.val1 / 488);
 		currentAngle += actualDegrees;
 
-		if (currentAngle > 359)
+		if (currentAngle >= 360)
 		{
 			currentAngle = (currentAngle % 360);
 		}

--- a/Transmitter/src/flashthissecond.c
+++ b/Transmitter/src/flashthissecond.c
@@ -3,6 +3,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <string.h>
+#include <math.h>
 #include <errno.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/byteorder.h>
@@ -29,8 +30,8 @@ const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(qdec0));
 static const struct gpio_dt_spec HESensor = GPIO_DT_SPEC_GET(HE0_NODE, gpios);
 static struct gpio_callback halleffect_cb_data;
 
-int currentAngle = 0; // Stores angle of rotation
-int actualDegrees = 0;
+float currentAngle = 0; // Stores angle of rotation
+float actualDegrees = 0;
 
 // ---------------------------- HALL EFFECT INTERRUPT -------------------------
 
@@ -102,12 +103,12 @@ int main(void)
 		sensor_sample_fetch(dev);
 		sensor_channel_get(dev, SENSOR_CHAN_ROTATION, &val);
 
-		actualDegrees = (val.val1 / 488);
+		actualDegrees = (val.val1 / 488.3);
 		currentAngle += actualDegrees;
 
 		if (currentAngle >= 360)
 		{
-			currentAngle = (currentAngle % 360);
+			currentAngle = fmod(currentAngle, 360);
 		}
 
 		//printk("Position = %d degrees\n", currentAngle);
@@ -116,8 +117,8 @@ int main(void)
 		
 		//transmit_addr.a.val[0]=transmit_addr.a.val[0]+1; // Alter transmitter address
 		int uniqueID = 10;
-		int angleHex = (currentAngle - (currentAngle % 16)) / 16;
-		int angleRemainder = currentAngle % 16;
+		int angleHex = (currentAngle - fmod(currentAngle, 16.0f)) / 16;
+		int angleRemainder = fmod(currentAngle, 16.0f);
 
 		// Get current clock cycle (clock runs at 32768 Hz on nrf52dk_nrf52832 & (presumably) on the EV-BT832X)
 		int systemClockSpeed = 32768;


### PR DESCRIPTION
- Angle readout stored and processed as float - rounding was a source of drift.
- Updated angle conversion to use 488.3:1 ratio as reported by the 488:1 Metal Gearmotor 20Dx46L mm 12V CB with Extended Motor Shaft data sheet.
- With float precision now being used, updated logic.